### PR TITLE
feat: add support for Adjust Partner Parameters

### DIFF
--- a/Example/Segment-Adjust/SEGAppDelegate.m
+++ b/Example/Segment-Adjust/SEGAppDelegate.m
@@ -24,7 +24,7 @@
 
     // Add any of your bundled integrations.
     [config use:[SEGAdjustIntegrationFactory instance]];
-    
+
     if (@available(iOS 14, *)) {
         [config setAdSupportBlock:^NSString * _Nonnull(void) {
             NSString *idfa = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];

--- a/Example/Segment-Adjust/SEGViewController.m
+++ b/Example/Segment-Adjust/SEGViewController.m
@@ -32,25 +32,25 @@
 
 
 - (void) addIDFATracking {
-    
+
     if (@available(iOS 14, *)) {
         if (ATTrackingManager.trackingAuthorizationStatus == ATTrackingManagerAuthorizationStatusNotDetermined){
             [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
-                
+
                 NSString *idfa = ASIdentifierManager.sharedManager.advertisingIdentifier.UUIDString;
                 NSString *idfv = UIDevice.currentDevice.identifierForVendor.UUIDString ? UIDevice.currentDevice.identifierForVendor.UUIDString : @"0000";
-                
+
                 if (status == ATTrackingManagerAuthorizationStatusAuthorized) {
                     [[SEGAnalytics sharedAnalytics] track:@"iOS14 tracking enabled"
                                                properties:@{ @"IDFA" : idfa,
                                                  @"IDFV" : idfv }];
-                    
+
                 } else {
                     [[SEGAnalytics sharedAnalytics] track:@"iOS14 tracking NOT enabled"
                                                properties:@{ @"IDFA" : idfa,
                                                  @"IDFV" : idfv }];
                 }
-                
+
                 // your authorization handler here
                 // note: the Singular SDK will automatically detect if authorization has been given and initialize itself
             }];

--- a/Pod/Classes/SEGAdjustIntegration.m
+++ b/Pod/Classes/SEGAdjustIntegration.m
@@ -51,21 +51,23 @@
     return self;
 }
 
-+ (NSDictionary *)extractPartnerParameters:(NSDictionary *)dictionary
++ (NSDictionary *)extractPartnerParameters:(NSDictionary *)integrations
 {
-    NSString *const adjustPartnerParameterPrefix = @"adjust_pp_";
+    NSMutableDictionary* partnerParametersDict = @{}.mutableCopy;
 
-    NSMutableDictionary* partnerParameters = @{}.mutableCopy;
+    if (integrations) {
+        NSDictionary * adjustConfig = integrations[@"Adjust"];
 
-    for (NSString *key in dictionary.allKeys) {
-        if ([[key lowercaseString] hasPrefix:adjustPartnerParameterPrefix]) {
-            id ppKey = [[key substringFromIndex:[adjustPartnerParameterPrefix length]] lowercaseString];
-            id value = dictionary[key];
-            partnerParameters[ppKey] = value;
+        if (adjustConfig) {
+            NSDictionary * partnerParameters = adjustConfig[@"partnerParameters"];
+
+            if (partnerParameters) {
+                partnerParametersDict = [partnerParameters copy];
+            }
         }
     }
 
-    return partnerParameters;
+    return partnerParametersDict;
 }
 
 + (NSNumber *)extractRevenue:(NSDictionary *)dictionary withKey:(NSString *)revenueKey
@@ -157,7 +159,7 @@
         NSString *currency = [SEGAdjustIntegration extractCurrency:payload.properties withKey:@"currency"];
 
         // Extract Adjust Partner Parameters
-        NSDictionary *partnerParameters = [SEGAdjustIntegration extractPartnerParameters:payload.properties];
+        NSDictionary *partnerParameters = [SEGAdjustIntegration extractPartnerParameters:payload.integrations];
 
         for (NSString *key in partnerParameters) {
             NSString *value = [NSString stringWithFormat:@"%@", [partnerParameters objectForKey:key]];

--- a/Pod/Classes/SEGAdjustIntegration.m
+++ b/Pod/Classes/SEGAdjustIntegration.m
@@ -51,18 +51,21 @@
     return self;
 }
 
-+ (NSDictionary *)extractPartnerParameters:(NSDictionary *)integrations
++ (NSDictionary *)extractPartnerParameters:(NSDictionary *)context
 {
     NSMutableDictionary* partnerParametersDict = @{}.mutableCopy;
 
-    if (integrations) {
-        NSDictionary * adjustConfig = integrations[@"Adjust"];
+    if (context) {
+        NSDictionary * integrations = context[@"integrations"];
+        if (integrations) {
+            NSDictionary * adjustConfig = integrations[@"Adjust"];
 
-        if (adjustConfig) {
-            NSDictionary * partnerParameters = adjustConfig[@"partnerParameters"];
+            if (adjustConfig) {
+                NSDictionary * partnerParameters = adjustConfig[@"partnerParameters"];
 
-            if (partnerParameters) {
-                partnerParametersDict = [partnerParameters copy];
+                if (partnerParameters) {
+                    partnerParametersDict = [partnerParameters copy];
+                }
             }
         }
     }
@@ -159,7 +162,7 @@
         NSString *currency = [SEGAdjustIntegration extractCurrency:payload.properties withKey:@"currency"];
 
         // Extract Adjust Partner Parameters
-        NSDictionary *partnerParameters = [SEGAdjustIntegration extractPartnerParameters:payload.integrations];
+        NSDictionary *partnerParameters = [SEGAdjustIntegration extractPartnerParameters:payload.context];
 
         for (NSString *key in partnerParameters) {
             NSString *value = [NSString stringWithFormat:@"%@", [partnerParameters objectForKey:key]];

--- a/Pod/Classes/SEGAdjustIntegration.m
+++ b/Pod/Classes/SEGAdjustIntegration.m
@@ -51,6 +51,23 @@
     return self;
 }
 
++ (NSDictionary *)extractPartnerParameters:(NSDictionary *)dictionary
+{
+    NSString *const adjustPartnerParameterPrefix = @"adjust_pp_";
+
+    NSMutableDictionary* partnerParameters = @{}.mutableCopy;
+
+    for (NSString *key in dictionary.allKeys) {
+        if ([[key lowercaseString] hasPrefix:adjustPartnerParameterPrefix]) {
+            id ppKey = [[key substringFromIndex:[adjustPartnerParameterPrefix length]] lowercaseString];
+            id value = dictionary[key];
+            partnerParameters[ppKey] = value;
+        }
+    }
+
+    return partnerParameters;
+}
+
 + (NSNumber *)extractRevenue:(NSDictionary *)dictionary withKey:(NSString *)revenueKey
 {
     id revenueProperty = nil;
@@ -138,6 +155,15 @@
         // Track revenue specifically
         NSNumber *revenue = [SEGAdjustIntegration extractRevenue:payload.properties withKey:@"revenue"];
         NSString *currency = [SEGAdjustIntegration extractCurrency:payload.properties withKey:@"currency"];
+
+        // Extract Adjust Partner Parameters
+        NSDictionary *partnerParameters = [SEGAdjustIntegration extractPartnerParameters:payload.properties];
+
+        for (NSString *key in partnerParameters) {
+            NSString *value = [NSString stringWithFormat:@"%@", [partnerParameters objectForKey:key]];
+            [event addPartnerParameter:key value:value];
+        }
+
         if (revenue) {
             [event setRevenue:[revenue doubleValue] currency:currency];
         }
@@ -192,7 +218,7 @@
         NSString *overwrittenToken = [tokens objectForKey:overwrittenEventName];
         return overwrittenToken;
     }
-    
+
 
     return token;
 }


### PR DESCRIPTION
# Overview
We need to enable Partner Parameters in Adjust https://help.adjust.com/en/article/record-events-ios-sdk#add-partner-parameters

Reasons to add this:
- FB CAPI Event deduplication
- Start sending product catalog info to networks

We will use the `integrations` object (sent in `context` for enabling sending this special parameters back to Adjust)

ie: 
```
{
  "context": {
    "integrations": {
      "Adjust": {
        "partnerParameters": {
          "event_id": 12345,
        }
      }
    }
  }
}
```

Note: this will require changes in the tracking plugin of segment in the new tracking library.